### PR TITLE
Update BloodArsenalEventHooks.java

### DIFF
--- a/src/main/java/com/arc/bloodarsenal/common/BloodArsenalEventHooks.java
+++ b/src/main/java/com/arc/bloodarsenal/common/BloodArsenalEventHooks.java
@@ -24,6 +24,7 @@ import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.common.util.FakePlayer;
 
 import java.util.Random;
 
@@ -208,7 +209,7 @@ public class BloodArsenalEventHooks
             EntityPlayer player = event.harvester;
             Random random = new Random();
 
-            if (player != null && player instanceof EntityPlayerMP)
+            if (player != null && player instanceof EntityPlayerMP && !(player instanceof FakePlayer))
             {
                 if (!event.world.isRemote && !event.isSilkTouching)
                 {


### PR DESCRIPTION
FakePlayer extends EntityPlayerMP (http://takahikokawasaki.github.io/minecraft-resources/javadoc/forge/1.7.10-10.13.2.1291/index.html)
and thus this method will try to give FakePlayers (In our case the ExtraUtilities EnderQuarry) the potion effect, that will cause an NPE and crash