### PR TITLE
fix ethereal blood stone -> broken potentia craft

### DIFF
--- a/src/main/java/com/arc/bloodarsenal/common/BloodArsenalRecipes.java
+++ b/src/main/java/com/arc/bloodarsenal/common/BloodArsenalRecipes.java
@@ -695,7 +695,7 @@ public class BloodArsenalRecipes {
                 new ItemStack(WayofTime.alchemicalWizardry.ModItems.demonicSlate, 9),
                 new ItemStack(ModBlocks.blood_stone, 1, 3));
         addShapelessOreDictRecipe(
-                new ItemStack(WayofTime.alchemicalWizardry.ModItems.baseAlchemyItems, 9, 27),
+                new ItemStack(WayofTime.alchemicalWizardry.ModItems.baseItems, 9, 27),
                 new ItemStack(ModBlocks.blood_stone, 1, 4));
         // This is a long one
         addShapelessOreDictRecipe(


### PR DESCRIPTION
the crafting recipe uses the wrong meta item, baseAlchemyItems instead of baseItems
and yep the fixed recipe is then correctly removed like the other block -> slates crafting table recipes (i assume by the coremod)

fixes
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8195
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11840