### PR TITLE
add nullcheck to Enchant ritual lp requirement message to avoid crash…

### DIFF
--- a/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
+++ b/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
@@ -143,7 +143,9 @@ public class RitualEffectEnchant extends RitualEffect {
                             lpRequired += (int) (500F * ((15 - Math.min(15, ench.getWeight())) * 1.05F)
                                     * ((3F + d.level * d.level) * 0.25F)
                                     * (0.9F + enchants.size() * 0.05F));
-                            player.addChatComponentMessage(new ChatComponentText("Lp required: " + lpRequired));
+                            if (player != null)
+                                player.addChatComponentMessage(new ChatComponentText("Lp required: " + lpRequired));
+
                             SoulNetworkHandler.syphonFromNetwork(owner, lpRequired);
                         }
                     } else if (SoulNetworkHandler.getCurrentEssence(owner) >= lpRequired) {


### PR DESCRIPTION
…ing server if ritual owner is not online

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15445

issue was cause by a null pointer exception from sending a message to a player that is not online by using their activation crystal.

If the player owning the activation crystal is not online,the message on how much LP was required is not sent.
Sending it to the player that activated the ritual does not seem to be possible because the information is not available.

it should be possible to send it to the player closest to the master ritual stone, but for now it will work without crashing the server