### PR TITLE
add null checks for all sendPlayerInformation cases,to avoid crashes …

### DIFF
--- a/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
+++ b/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
@@ -366,6 +366,7 @@ public class RitualEffectEnchant extends RitualEffect {
     }
 
     private static void sendPlayerInformation(EntityPlayer player, int number) {
+        if (player == null) return;
         switch (number) {
             case 1:
                 player.addChatComponentMessage(

--- a/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
+++ b/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
@@ -368,28 +368,40 @@ public class RitualEffectEnchant extends RitualEffect {
     private static void sendPlayerInformation(EntityPlayer player, int number) {
         switch (number) {
             case 1:
-                player.addChatComponentMessage(
-                        new ChatComponentText(StatCollector.translateToLocal("message.enchant.noAltar")));
+                if (player != null) {
+                    player.addChatComponentMessage(
+                            new ChatComponentText(StatCollector.translateToLocal("message.enchant.noAltar")));
+                }
                 break;
             case 2:
-                player.addChatComponentMessage(
-                        new ChatComponentText(StatCollector.translateToLocal("message.enchant.noPedestals")));
+                if (player != null) {
+                    player.addChatComponentMessage(
+                            new ChatComponentText(StatCollector.translateToLocal("message.enchant.noPedestals")));
+                }
                 break;
             case 3:
-                player.addChatComponentMessage(
-                        new ChatComponentText(StatCollector.translateToLocal("message.enchant.noEnchantItem")));
+                if (player != null) {
+                    player.addChatComponentMessage(
+                            new ChatComponentText(StatCollector.translateToLocal("message.enchant.noEnchantItem")));
+                }
                 break;
             case 4:
-                player.addChatComponentMessage(
-                        new ChatComponentText(StatCollector.translateToLocal("message.enchant.noEnchantments")));
+                if (player != null) {
+                    player.addChatComponentMessage(
+                            new ChatComponentText(StatCollector.translateToLocal("message.enchant.noEnchantments")));
+                }
                 break;
             case 5:
-                player.addChatComponentMessage(
-                        new ChatComponentText(StatCollector.translateToLocal("message.enchant.notEnoughLP")));
+                if (player != null) {
+                    player.addChatComponentMessage(
+                            new ChatComponentText(StatCollector.translateToLocal("message.enchant.notEnoughLP")));
+                }
                 break;
             case 6:
-                player.addChatComponentMessage(
-                        new ChatComponentText(StatCollector.translateToLocal("message.enchant.enchantIsNotValid")));
+                if (player != null) {
+                    player.addChatComponentMessage(
+                            new ChatComponentText(StatCollector.translateToLocal("message.enchant.enchantIsNotValid")));
+                }
                 break;
         }
     }

--- a/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
+++ b/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
@@ -368,40 +368,28 @@ public class RitualEffectEnchant extends RitualEffect {
     private static void sendPlayerInformation(EntityPlayer player, int number) {
         switch (number) {
             case 1:
-                if (player != null) {
-                    player.addChatComponentMessage(
-                            new ChatComponentText(StatCollector.translateToLocal("message.enchant.noAltar")));
-                }
+                player.addChatComponentMessage(
+                        new ChatComponentText(StatCollector.translateToLocal("message.enchant.noAltar")));
                 break;
             case 2:
-                if (player != null) {
-                    player.addChatComponentMessage(
-                            new ChatComponentText(StatCollector.translateToLocal("message.enchant.noPedestals")));
-                }
+                player.addChatComponentMessage(
+                        new ChatComponentText(StatCollector.translateToLocal("message.enchant.noPedestals")));
                 break;
             case 3:
-                if (player != null) {
-                    player.addChatComponentMessage(
-                            new ChatComponentText(StatCollector.translateToLocal("message.enchant.noEnchantItem")));
-                }
+                player.addChatComponentMessage(
+                        new ChatComponentText(StatCollector.translateToLocal("message.enchant.noEnchantItem")));
                 break;
             case 4:
-                if (player != null) {
-                    player.addChatComponentMessage(
-                            new ChatComponentText(StatCollector.translateToLocal("message.enchant.noEnchantments")));
-                }
+                player.addChatComponentMessage(
+                        new ChatComponentText(StatCollector.translateToLocal("message.enchant.noEnchantments")));
                 break;
             case 5:
-                if (player != null) {
-                    player.addChatComponentMessage(
-                            new ChatComponentText(StatCollector.translateToLocal("message.enchant.notEnoughLP")));
-                }
+                player.addChatComponentMessage(
+                        new ChatComponentText(StatCollector.translateToLocal("message.enchant.notEnoughLP")));
                 break;
             case 6:
-                if (player != null) {
-                    player.addChatComponentMessage(
-                            new ChatComponentText(StatCollector.translateToLocal("message.enchant.enchantIsNotValid")));
-                }
+                player.addChatComponentMessage(
+                        new ChatComponentText(StatCollector.translateToLocal("message.enchant.enchantIsNotValid")));
                 break;
         }
     }


### PR DESCRIPTION
…if ritual owner is not online and

1. Altar is missing
2. Pedestals are missing
3. Item to enchant is missing
4. Enchantment books are missing
5. Not enough LP in the network to enchant items
6. Enchantment type can not be applied on item

flew under the radar because they only happen under specific conditions and were not part of the issue because of it