### PR TITLE
Fix Transparent Orb tooltips and rendering on multiplayer

### DIFF
--- a/src/main/java/com/arc/bloodarsenal/common/items/orb/TransparentOrb.java
+++ b/src/main/java/com/arc/bloodarsenal/common/items/orb/TransparentOrb.java
@@ -32,9 +32,11 @@ public class TransparentOrb extends EnergyBattery {
             list.add(
                     StatCollector.translateToLocal("tooltip.owner.currentowner") + " "
                             + itemStack.getTagCompound().getString("ownerName"));
+            if (MinecraftServer.getServer() != null) {
             list.add(
                     StatCollector.translateToLocal("tooltip.energybattery.currentLP") + " "
                             + this.getCurrentEssence(itemStack));
+            }
         }
     }
 
@@ -43,7 +45,9 @@ public class TransparentOrb extends EnergyBattery {
         if (itemStack.getTagCompound() == null) {
             return;
         }
-
+        if (world.isRemote) {
+            return;//changes of metadata will be synced to client, no need to proceed on client
+        }
         int maxEssence = SoulNetworkHandler
                 .getMaximumForOrbTier(SoulNetworkHandler.getCurrentMaxOrb(SoulNetworkHandler.getOwnerName(itemStack)));
         int section = maxEssence / 44;

--- a/src/main/java/com/arc/bloodarsenal/common/items/orb/TransparentOrb.java
+++ b/src/main/java/com/arc/bloodarsenal/common/items/orb/TransparentOrb.java
@@ -32,11 +32,11 @@ public class TransparentOrb extends EnergyBattery {
             list.add(
                     StatCollector.translateToLocal("tooltip.owner.currentowner") + " "
                             + itemStack.getTagCompound().getString("ownerName"));
-            if (MinecraftServer.getServer() != null) {
+
             list.add(
                     StatCollector.translateToLocal("tooltip.energybattery.currentLP") + " "
-                            + this.getCurrentEssence(itemStack));
-            }
+                            + itemStack.getTagCompound().getInteger("essenceAmount"));
+
         }
     }
 
@@ -46,8 +46,13 @@ public class TransparentOrb extends EnergyBattery {
             return;
         }
         if (world.isRemote) {
-            return;//changes of metadata will be synced to client, no need to proceed on client
+            return;// changes of metadata and NBT will be synced to client, no need to proceed on client
         }
+
+        if (itemStack.getTagCompound().hasKey("ownerName")) {
+            itemStack.getTagCompound().setInteger("essenceAmount", this.getCurrentEssence(itemStack));
+        }
+
         int maxEssence = SoulNetworkHandler
                 .getMaximumForOrbTier(SoulNetworkHandler.getCurrentMaxOrb(SoulNetworkHandler.getOwnerName(itemStack)));
         int section = maxEssence / 44;
@@ -55,6 +60,9 @@ public class TransparentOrb extends EnergyBattery {
 
         if (currentEssence > 0) {
             int metaToBe = (currentEssence / section);
+            if (metaToBe >= 44) {
+                metaToBe = 44;
+            }
             itemStack.setItemDamage(metaToBe);
         } else {
             itemStack.setItemDamage(0);


### PR DESCRIPTION
TransparentOrb has some bugs on dedicated server:
1. Cannot render LP in its icon, it always looks empty
2. Cannot display current LP in tooltips, its name turns to 'Unnamed' when bound to player.![2024-12-05_22 51 59](https://github.com/user-attachments/assets/eeb158e4-5eb9-45af-ba0c-8150af405152)
3. Crash the client when open a ModularUI with such orb in inventory.
[crash-2024-12-05_22.56.23-client.txt](https://github.com/user-attachments/files/18026683/crash-2024-12-05_22.56.23-client.txt)

This is caused by:
TransparentOrb calls some server-only methods('getCurrentEssence'/'getCurrentMaxOrb').
On integreted server(single player mode), client&server runs on the same jvm instance, so it's okay.
But on dedicated server, things are broken. 
And normal GUI catch Exceptions thrown when getting tooltips and show 'Unnamed' as its name, but ModularUI is unguarded so game crashes.

This PR:
Prevent invalid calls to server-only methods on client and fix icon display.
Pass current LP to client via NBT.
Cap metadata to maxdamage to make sure that Armok Orb(it's a T6 orb but its max essence exceeds T6 limit) will not break the icon display.

Video: Test on dedicated server

https://github.com/user-attachments/assets/d8c6606b-f8e2-4687-88c9-7ddc767a51ca


