### PR TITLE
Compacter NPE Bugfix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -41,11 +41,11 @@ developmentEnvironmentUserName = Developer
 
 # Enables using modern Java syntax (up to version 17) via Jabel, while still targeting JVM 8.
 # See https://github.com/bsideup/jabel for details on how this works.
-enableModernJavaSyntax = false
+enableModernJavaSyntax = true
 
 # Enables injecting missing generics into the decompiled source code for a better coding experience.
 # Turns most publicly visible List, Map, etc. into proper List<E>, Map<K, V> types.
-enableGenericInjection = false
+enableGenericInjection = true
 
 # Generate a class with a String field for the mod version named as defined below.
 # If generateGradleTokenClass is empty or not missing, no such class will be generated.

--- a/src/main/java/com/arc/bloodarsenal/common/block/BlockCompacter.java
+++ b/src/main/java/com/arc/bloodarsenal/common/block/BlockCompacter.java
@@ -8,7 +8,6 @@ import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.effect.EntityLightningBolt;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChatComponentText;

--- a/src/main/java/com/arc/bloodarsenal/common/block/BlockCompacter.java
+++ b/src/main/java/com/arc/bloodarsenal/common/block/BlockCompacter.java
@@ -10,9 +10,8 @@ import net.minecraft.entity.effect.EntityLightningBolt;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.IIcon;
-import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidContainerRegistry;
 
@@ -135,8 +134,7 @@ public class BlockCompacter extends BlockContainer {
                 SoulNetworkHandler.syphonFromNetwork(owner, cost);
                 --player.inventory.getCurrentItem().stackSize;
             } else {
-                player.addChatComponentMessage(
-                        new ChatComponentText(StatCollector.translateToLocal("message.compacter.notEnoughLP")));
+                player.addChatComponentMessage(new ChatComponentTranslation("message.compacter.notEnoughLP"));
             }
         } else if (block instanceof BlockAltar && world.getTileEntity(x, y + 1, z) != null) {
             tile = world.getTileEntity(x, y + 1, z);
@@ -148,13 +146,11 @@ public class BlockCompacter extends BlockContainer {
                 return false;
             }
             if (altar.getStackInSlot(0) != null) {
-                player.addChatComponentMessage(
-                        new ChatComponentText(StatCollector.translateToLocal("message.compacter.itemInAltar")));
+                player.addChatComponentMessage(new ChatComponentTranslation("message.compacter.itemInAltar"));
                 return true;
             }
             if (bloodOrb.getOrbLevel() < tier) {
-                player.addChatComponentMessage(
-                        new ChatComponentText(StatCollector.translateToLocal("message.compacter.wrongOrbTier")));
+                player.addChatComponentMessage(new ChatComponentTranslation("message.compacter.wrongOrbTier"));
                 return true;
             }
 
@@ -167,8 +163,7 @@ public class BlockCompacter extends BlockContainer {
                 SoulNetworkHandler.syphonFromNetwork(owner, cost);
                 --player.inventory.getCurrentItem().stackSize;
             } else {
-                player.addChatComponentMessage(
-                        new ChatComponentText(StatCollector.translateToLocal("message.compacter.notEnoughLP")));
+                player.addChatComponentMessage(new ChatComponentTranslation("message.compacter.notEnoughLP"));
             }
         }
         return true;

--- a/src/main/java/com/arc/bloodarsenal/common/block/BlockCompacter.java
+++ b/src/main/java/com/arc/bloodarsenal/common/block/BlockCompacter.java
@@ -76,168 +76,113 @@ public class BlockCompacter extends BlockContainer {
     }
 
     @Override
-    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int idk, float what,
-            float these, float are) {
+    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX,
+            float hitY, float hitZ) {
         world.markBlockForUpdate(x, y, z);
         TileEntity tileEntity = world.getTileEntity(x, y, z);
-
-        if (tileEntity != null && !player.isSneaking()) {
-            ItemStack playerItem = player.getCurrentEquippedItem();
-
-            if (playerItem == null) {
-                return false;
-            } else {
-                Item item = playerItem.getItem();
-
-                if (!(item instanceof IBloodOrb)) {
-                    return false;
-                } else {
-                    Block block = world.getBlock(x, y + 1, z);
-
-                    if (block != null) {
-                        TileEntity tile;
-
-                        world.markBlockForUpdate(x, y, z);
-                        world.markBlockForUpdate(x, y + 1, z);
-
-                        String owner = player.getCommandSenderName();
-                        int currentEssence = SoulNetworkHandler.getCurrentEssence(owner);
-
-                        if (block instanceof BlockMasterStone) {
-                            tile = world.getTileEntity(x, y + 1, z);
-
-                            checkRitual(tile);
-
-                            List<RitualComponent> ritualList = Rituals.getRitualList(ritualName);
-
-                            if (ritualList == null) {
-                                return false;
-                            } else {
-                                float multiplier = 1;
-
-                                for (RitualComponent ritualComponent : ritualList) {
-                                    int stoneType = ritualComponent.getStoneType();
-
-                                    switch (stoneType) {
-                                        case 0:
-                                            break;
-
-                                        case 1:
-                                            multiplier = multiplier * 1.05F;
-                                            break;
-
-                                        case 2:
-                                            multiplier = multiplier * 1.05F;
-                                            break;
-
-                                        case 3:
-                                            multiplier = multiplier * 1.05F;
-                                            break;
-
-                                        case 4:
-                                            multiplier = multiplier * 1.05F;
-                                            break;
-
-                                        case 5:
-                                            multiplier = multiplier * 1.075F;
-                                            break;
-                                    }
-                                }
-
-                                int activationCost = Rituals.getCostForActivation(ritualName);
-                                int cost = (activationCost * (int) multiplier) / 2; // Divided by 2 since this fires
-                                                                                    // twice apparently and also because
-                                                                                    // I'm nice
-
-                                if (cost <= currentEssence) {
-                                    compactRitual(tile);
-                                    SoulNetworkHandler.syphonFromNetwork(owner, cost);
-                                    --player.inventory.getCurrentItem().stackSize;
-                                } else {
-                                    player.addChatComponentMessage(
-                                            new ChatComponentText(
-                                                    StatCollector.translateToLocal("message.compacter.notEnoughLP")));
-                                    return true;
-                                }
-                            }
-
-                            return true;
-                        } else if (block instanceof BlockAltar && world.getTileEntity(x, y + 1, z) != null) {
-                            tile = world.getTileEntity(x, y + 1, z);
-
-                            TEAltar altar = (TEAltar) tile;
-                            checkAltar(altar);
-
-                            if (tier == 0) {
-                                return false;
-                            } else if (altar.getStackInSlot(0) != null) {
-                                player.addChatComponentMessage(
-                                        new ChatComponentText(
-                                                StatCollector.translateToLocal("message.compacter.itemInAltar")));
-                            } else {
-                                float multiplier = 1;
-
-                                AltarUpgradeComponent upgradeComponent = UpgradedAltars
-                                        .getUpgrades(world, x, y + 1, z, tier);
-
-                                int speedUpgrades = upgradeComponent.getSpeedUpgrades();
-                                int efficiencyUpgrades = upgradeComponent.getEfficiencyUpgrades();
-                                int sacrificeUpgrades = upgradeComponent.getSacrificeUpgrades();
-                                int selfSacrificeUpgrades = upgradeComponent.getSelfSacrificeUpgrades();
-                                int displacementUpgrades = upgradeComponent.getDisplacementUpgrades();
-                                int altarCapacitiveUpgrades = upgradeComponent.getAltarCapacitiveUpgrades();
-                                int orbCapacitiveUpgrades = upgradeComponent.getOrbCapacitiveUpgrades();
-                                int betterCapacitiveUpgrades = upgradeComponent.getBetterCapacitiveUpgrades();
-                                int accelerationUpgrades = upgradeComponent.getAccelerationUpgrades();
-
-                                multiplier = multiplier * ((speedUpgrades + 4) / 4);
-                                multiplier = multiplier * ((efficiencyUpgrades + 3) / 3);
-                                multiplier = multiplier * ((sacrificeUpgrades + 3) / 3);
-                                multiplier = multiplier * ((selfSacrificeUpgrades + 3) / 3);
-                                multiplier = multiplier * ((displacementUpgrades + 3) / 3);
-                                multiplier = multiplier * ((altarCapacitiveUpgrades + 3) / 3);
-                                multiplier = multiplier * ((orbCapacitiveUpgrades + 3) / 3);
-                                multiplier = multiplier * ((betterCapacitiveUpgrades + 2) / 2);
-                                multiplier = multiplier * ((accelerationUpgrades + 3) / 3);
-
-                                IBloodOrb bloodOrb = (IBloodOrb) item;
-
-                                if (bloodOrb.getOrbLevel() >= tier) {
-                                    int cost = ((tier * 10) * (int) (multiplier * 5)) + capacity;
-
-                                    if (cost <= currentEssence) {
-                                        compactAltar(tile);
-                                        SoulNetworkHandler.syphonFromNetwork(owner, cost);
-                                        --player.inventory.getCurrentItem().stackSize;
-                                    } else {
-                                        player.addChatComponentMessage(
-                                                new ChatComponentText(
-                                                        StatCollector
-                                                                .translateToLocal("message.compacter.notEnoughLP")));
-                                    }
-                                } else {
-                                    player.addChatComponentMessage(
-                                            new ChatComponentText(
-                                                    StatCollector.translateToLocal("message.compacter.wrongOrbTier")));
-                                }
-                            }
-
-                            return true;
-                        }
-                    }
-
-                    return true;
-                }
-            }
-        } else {
+        if (tileEntity == null || player.isSneaking()) {
             return false;
         }
+
+        ItemStack playerItem = player.getCurrentEquippedItem();
+        if (playerItem == null) {
+            return false;
+        }
+
+        if (!(playerItem.getItem() instanceof IBloodOrb bloodOrb)) {
+            return false;
+        }
+        if (player.worldObj.isRemote) return true;
+
+        Block block = world.getBlock(x, y + 1, z);
+
+        if (block == null) {
+            return true;
+        }
+
+        TileEntity tile;
+
+        world.markBlockForUpdate(x, y, z);
+        world.markBlockForUpdate(x, y + 1, z);
+
+        String owner = player.getCommandSenderName();
+        int currentEssence = SoulNetworkHandler.getCurrentEssence(owner);
+
+        if (block instanceof BlockMasterStone) {
+            tile = world.getTileEntity(x, y + 1, z);
+
+            checkRitual(tile);
+
+            List<RitualComponent> ritualList = Rituals.getRitualList(ritualName);
+
+            if (ritualList == null) {
+                return false;
+            }
+
+            float multiplier = 1;
+
+            for (RitualComponent ritualComponent : ritualList) {
+                switch (ritualComponent.getStoneType()) {
+                    case 1, 2, 3, 4 -> multiplier *= 1.05F;
+                    case 5, 6 -> multiplier *= 1.075F;
+                }
+            }
+
+            int activationCost = Rituals.getCostForActivation(ritualName);
+            int cost = (int) (activationCost * multiplier);
+
+            if (cost <= currentEssence) {
+                compactRitual(tile);
+                SoulNetworkHandler.syphonFromNetwork(owner, cost);
+                --player.inventory.getCurrentItem().stackSize;
+            } else {
+                player.addChatComponentMessage(
+                        new ChatComponentText(StatCollector.translateToLocal("message.compacter.notEnoughLP")));
+            }
+        } else if (block instanceof BlockAltar && world.getTileEntity(x, y + 1, z) != null) {
+            tile = world.getTileEntity(x, y + 1, z);
+
+            TEAltar altar = (TEAltar) tile;
+            checkAltar(altar);
+
+            if (tier == 0) {
+                return false;
+            }
+            if (altar.getStackInSlot(0) != null) {
+                player.addChatComponentMessage(
+                        new ChatComponentText(StatCollector.translateToLocal("message.compacter.itemInAltar")));
+                return true;
+            }
+            if (bloodOrb.getOrbLevel() < tier) {
+                player.addChatComponentMessage(
+                        new ChatComponentText(StatCollector.translateToLocal("message.compacter.wrongOrbTier")));
+                return true;
+            }
+
+            AltarUpgradeComponent upgradeComponent = UpgradedAltars.getUpgrades(world, x, y + 1, z, tier);
+
+            int cost = getAltarCost(upgradeComponent);
+
+            if (cost <= currentEssence) {
+                compactAltar(tile);
+                SoulNetworkHandler.syphonFromNetwork(owner, cost);
+                --player.inventory.getCurrentItem().stackSize;
+            } else {
+                player.addChatComponentMessage(
+                        new ChatComponentText(StatCollector.translateToLocal("message.compacter.notEnoughLP")));
+            }
+        }
+        return true;
     }
 
     @Override
     @SideOnly(Side.CLIENT)
     public IIcon getIcon(int side, int meta) {
-        return side == 1 ? this.topIcon : (side == 0 ? this.blockIcon : this.sideIcon);
+        return switch (side) {
+            case 0 -> blockIcon;
+            case 1 -> topIcon;
+            default -> sideIcon;
+        };
     }
 
     @Override
@@ -261,13 +206,11 @@ public class BlockCompacter extends BlockContainer {
         int z = masterStone.zCoord;
 
         ritualName = Rituals.checkValidRitual(world, x, y, z);
-
-        if (ritualName.equals("")) {
+        if (ritualName.isEmpty()) {
             return;
-        } else {
-            direction = Rituals.getDirectionOfRitual(world, x, y, z, ritualName);
         }
 
+        direction = Rituals.getDirectionOfRitual(world, x, y, z, ritualName);
         world.markBlockForUpdate(x, y, z);
         world.markBlockForUpdate(x, y + 1, z);
     }
@@ -327,6 +270,7 @@ public class BlockCompacter extends BlockContainer {
         }
 
         AltarUpgradeComponent upgrades = UpgradedAltars.getUpgrades(world, x, y, z, tier);
+        lpAmount = altar.getFluidAmount();
 
         if (upgrades == null) {
             this.consumptionMultiplier = 0;
@@ -337,10 +281,11 @@ public class BlockCompacter extends BlockContainer {
             this.orbCapacityMultiplier = 1;
             this.dislocationMultiplier = 1;
             this.accelerationUpgrades = 0;
+            world.markBlockForUpdate(x, y, z);
+            world.markBlockForUpdate(x, y - 1, z);
             return;
         }
 
-        lpAmount = altar.getFluidAmount();
         consumptionMultiplier = (float) (0.25 * upgrades.getSpeedUpgrades());
         efficiencyMultiplier = (float) Math.pow(0.80, upgrades.getSpeedUpgrades());
         sacrificeEfficiencyMultiplier = (float) (0.12 * upgrades.getSacrificeUpgrades());
@@ -378,7 +323,6 @@ public class BlockCompacter extends BlockContainer {
         if (altarComponents != null && !world.isRemote) {
             for (AltarComponent altarComponent : altarComponents) {
                 world.setBlockToAir(x + altarComponent.getX(), y + altarComponent.getY(), z + altarComponent.getZ());
-                world.setBlockToAir(x, y, z);
                 world.markBlockForUpdate(
                         x + altarComponent.getX(),
                         y + altarComponent.getY(),
@@ -394,36 +338,62 @@ public class BlockCompacter extends BlockContainer {
     }
 
     private void configureAltar(World world, int x, int y, int z, Block block) {
-        if (block instanceof BlockPortableAltar) {
-            if (world.getBlock(x, y, z) == block) {
-                TilePortableAltar altar = (TilePortableAltar) world.getTileEntity(x, y, z);
-
-                altar.setTier(tier);
-                altar.setCurrentBlood(lpAmount);
-                altar.setConsumptionMultiplier(consumptionMultiplier);
-                altar.setEfficiencyMultiplier(efficiencyMultiplier);
-                altar.setSacrificeMultiplier(sacrificeEfficiencyMultiplier);
-                altar.setSelfSacrificeMultiplier(selfSacrificeEfficiencyMultiplier);
-                altar.setOrbMultiplier(orbCapacityMultiplier);
-                altar.setDislocationMultiplier(dislocationMultiplier);
-                altar.setCapacityMultiplier(capacityMultiplier);
-                altar.setCapacity(capacity);
-                altar.setBufferCapacity(bufferCapacity);
-                altar.setUpgrades(
-                        speedUpgrades,
-                        efficiencyUpgrades,
-                        sacrificeUpgrades,
-                        selfSacrificeUpgrades,
-                        displacementUpgrades,
-                        altarCapacitiveUpgrades,
-                        orbCapacitiveUpgrades,
-                        betterCapacitiveUpgrades,
-                        accelerationUpgrades);
-
-                world.markBlockForUpdate(x, y, z);
-
-                world.addWeatherEffect(new EntityLightningBolt(world, x, y, z));
-            }
+        if (!(block instanceof BlockPortableAltar) || world.getBlock(x, y, z) != block) {
+            return;
         }
+
+        TilePortableAltar altar = (TilePortableAltar) world.getTileEntity(x, y, z);
+
+        altar.setTier(tier);
+        altar.setCurrentBlood(lpAmount);
+        altar.setConsumptionMultiplier(consumptionMultiplier);
+        altar.setEfficiencyMultiplier(efficiencyMultiplier);
+        altar.setSacrificeMultiplier(sacrificeEfficiencyMultiplier);
+        altar.setSelfSacrificeMultiplier(selfSacrificeEfficiencyMultiplier);
+        altar.setOrbMultiplier(orbCapacityMultiplier);
+        altar.setDislocationMultiplier(dislocationMultiplier);
+        altar.setCapacityMultiplier(capacityMultiplier);
+        altar.setCapacity(capacity);
+        altar.setBufferCapacity(bufferCapacity);
+        altar.setUpgrades(
+                speedUpgrades,
+                efficiencyUpgrades,
+                sacrificeUpgrades,
+                selfSacrificeUpgrades,
+                displacementUpgrades,
+                altarCapacitiveUpgrades,
+                orbCapacitiveUpgrades,
+                betterCapacitiveUpgrades,
+                accelerationUpgrades);
+
+        world.markBlockForUpdate(x, y, z);
+
+        world.addWeatherEffect(new EntityLightningBolt(world, x, y, z));
+    }
+
+    private int getAltarCost(AltarUpgradeComponent upgradeComponent) {
+        float multiplier = 1;
+
+        int speedUpgrades = upgradeComponent.getSpeedUpgrades();
+        int efficiencyUpgrades = upgradeComponent.getEfficiencyUpgrades();
+        int sacrificeUpgrades = upgradeComponent.getSacrificeUpgrades();
+        int selfSacrificeUpgrades = upgradeComponent.getSelfSacrificeUpgrades();
+        int displacementUpgrades = upgradeComponent.getDisplacementUpgrades();
+        int altarCapacitiveUpgrades = upgradeComponent.getAltarCapacitiveUpgrades();
+        int orbCapacitiveUpgrades = upgradeComponent.getOrbCapacitiveUpgrades();
+        int betterCapacitiveUpgrades = upgradeComponent.getBetterCapacitiveUpgrades();
+        int accelerationUpgrades = upgradeComponent.getAccelerationUpgrades();
+
+        multiplier *= (speedUpgrades + 4) / 4.0F;
+        multiplier *= (efficiencyUpgrades + 3) / 3.0F;
+        multiplier *= (sacrificeUpgrades + 3) / 3.0F;
+        multiplier *= (selfSacrificeUpgrades + 3) / 3.0F;
+        multiplier *= (displacementUpgrades + 3) / 3.0F;
+        multiplier *= (altarCapacitiveUpgrades + 3) / 3.0F;
+        multiplier *= (orbCapacitiveUpgrades + 3) / 3.0F;
+        multiplier *= (betterCapacitiveUpgrades + 2) / 2.0F;
+        multiplier *= (accelerationUpgrades + 3) / 3.0F;
+
+        return ((tier * 10) * (int) (multiplier * 10)) + capacity;
     }
 }

--- a/src/main/java/com/arc/bloodarsenal/common/items/tool/InfusedDiamondSword.java
+++ b/src/main/java/com/arc/bloodarsenal/common/items/tool/InfusedDiamondSword.java
@@ -56,9 +56,7 @@ public class InfusedDiamondSword extends ItemSword implements IBindable {
 
     @Override
     public boolean onLeftClickEntity(ItemStack stack, EntityPlayer player, Entity entity) {
-        if (!ignoreLeftClick && entity instanceof EntityLivingBase
-                && ((EntityLivingBase) entity).hurtTime == 0
-                && !((EntityLivingBase) entity).isDead) {
+        if (!ignoreLeftClick && entity instanceof EntityLivingBase e && e.hurtTime == 0 && !e.isDead) {
             switch (ToolCapabilities.getMode(stack)) {
                 case 0: {
                     if (!player.capabilities.isCreativeMode) {
@@ -68,7 +66,7 @@ public class InfusedDiamondSword extends ItemSword implements IBindable {
                 }
                 case 1: {
                     int range = 3;
-                    List<Entity> entities = player.worldObj.getEntitiesWithinAABB(
+                    List<? extends Entity> entities = player.worldObj.getEntitiesWithinAABB(
                             entity.getClass(),
                             AxisAlignedBB.getBoundingBox(
                                     entity.posX - range,
@@ -90,8 +88,7 @@ public class InfusedDiamondSword extends ItemSword implements IBindable {
                     break;
                 }
                 case 2: {
-                    EntityLivingBase living = (EntityLivingBase) entity;
-                    living.setFire(3);
+                    e.setFire(3);
 
                     if (!player.capabilities.isCreativeMode) {
                         EnergyItems.syphonBatteries(stack, player, 300);


### PR DESCRIPTION
First, this enables Jabel and generic injection and fixes a problem caused by doing that.

Then, it fixes an NPE when using the Soul Compacter to compact a Blood Altar, which happened every time it was used because the logic ran on both the server and client thread, and the client thread returns `null` from `UpgradedAltars::getUpgrades`. Fixing that also fixed a bug where LP would be deducted twice. Costs were doubled to match the old values.

Dawn runes now also use the same multiplier as Dusk runes when compacting rituals.