### PR TITLE
Fix negative enchantment levels + negative LP cost

### DIFF
--- a/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
+++ b/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
@@ -35,6 +35,7 @@ public class RitualEffectEnchant extends RitualEffect {
     public int stage3EndTicks = 0;
 
     int lpRequired = -1;
+    boolean tooExpensive = false;
 
     public ItemStack enchantItem = null;
     public List<EnchantmentData> enchants = new ArrayList<>();
@@ -137,20 +138,24 @@ public class RitualEffectEnchant extends RitualEffect {
                 case 2: {
                     if (lpRequired == -1) {
                         lpRequired = 0;
+                        tooExpensive = false;
 
                         for (EnchantmentData d : enchants) {
                             Enchantment ench = Enchantment.enchantmentsList[d.enchant];
-                            lpRequired += (int) Math.min(
-                                    1E8F,
-                                    500F * (Math.max(0, 15 - Math.min(15, ench.getWeight())) * 1.05F)
-                                            * ((3F + d.level * d.level) * 0.25F)
-                                            * (0.9F + enchants.size() * 0.05F));
-                            if (lpRequired < 0) {
+                            double lpDiff = Math.min(
+                                    (double) Integer.MAX_VALUE,
+                                    500D * (Math.max(0, 15 - Math.min(15, ench.getWeight())) * 1.05D)
+                                            * ((3D + d.level * d.level) * 0.25D)
+                                            * (0.9D + enchants.size() * 0.05D));
+                            if (lpDiff + (double) lpRequired > (double) Integer.MAX_VALUE) {
+                                tooExpensive = true;
                                 lpRequired = Integer.MAX_VALUE;
                                 break;
                             }
+                            lpRequired += (int) lpDiff;
+                            // lpRequired is an int so this can't sneak an overflow past prev check
                         }
-                        if (player != null)
+                        if (player != null && !tooExpensive)
                             player.addChatComponentMessage(new ChatComponentText("Lp required: " + lpRequired));
                     }
                     if (SoulNetworkHandler.getCurrentEssence(owner) >= lpRequired) {

--- a/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
+++ b/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
@@ -37,8 +37,8 @@ public class RitualEffectEnchant extends RitualEffect {
     int lpRequired = -1;
 
     public ItemStack enchantItem = null;
-    public List<EnchantmentData> enchants = new ArrayList();
-    // public List<ItemStack> itemList = new ArrayList();
+    public List<EnchantmentData> enchants = new ArrayList<>();
+    // public List<ItemStack> itemList = new ArrayList<>();
 
     @Override
     public void performEffect(IMasterRitualStone ritualStone) {

--- a/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
+++ b/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
@@ -144,7 +144,8 @@ public class RitualEffectEnchant extends RitualEffect {
                             double lpDiff = Math.min(
                                     (double) Integer.MAX_VALUE,
                                     500D * (15D / (double) ench.getWeight() * 1.05D)
-                                            * (0.75D + 2.25D * (double) d.level / (double) d.getMaxLevel())
+                                            * (0.75D + 2.25D * (double) d.level
+                                            / (double) Enchantment.enchantmentsList[d.enchant].getMaxLevel())
                                             * (0.9D + enchants.size() * 0.05D));
                             if (lpDiff + (double) lpRequired > (double) Integer.MAX_VALUE) {
                                 lpRequired = Integer.MAX_VALUE;

--- a/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
+++ b/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
@@ -145,7 +145,7 @@ public class RitualEffectEnchant extends RitualEffect {
                                     (double) Integer.MAX_VALUE,
                                     500D * (15D / (double) ench.getWeight() * 1.05D)
                                             * (0.75D + 2.25D * (double) d.level
-                                            / (double) Enchantment.enchantmentsList[d.enchant].getMaxLevel())
+                                                    / (double) Enchantment.enchantmentsList[d.enchant].getMaxLevel())
                                             * (0.9D + enchants.size() * 0.05D));
                             if (lpDiff + (double) lpRequired > (double) Integer.MAX_VALUE) {
                                 lpRequired = Integer.MAX_VALUE;

--- a/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
+++ b/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
@@ -145,8 +145,11 @@ public class RitualEffectEnchant extends RitualEffect {
                                     500F * (Math.max(0, 15 - Math.min(15, ench.getWeight())) * 1.05F)
                                             * ((3F + d.level * d.level) * 0.25F)
                                             * (0.9F + enchants.size() * 0.05F));
+                            if (lpRequired < 0) {
+                                lpRequired = Integer.MAX_VALUE;
+                                break;
+                            }
                         }
-                        if (lpRequired < 0) lpRequired = Integer.MAX_VALUE;
                         if (player != null)
                             player.addChatComponentMessage(new ChatComponentText("Lp required: " + lpRequired));
                     }

--- a/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
+++ b/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
@@ -144,7 +144,7 @@ public class RitualEffectEnchant extends RitualEffect {
                             double lpDiff = Math.min(
                                     (double) Integer.MAX_VALUE,
                                     500D * (15D / (double) ench.getWeight() * 1.05D)
-                                            * ((double) d.level * ((double) d.level * .01D + 5D) * 0.25D)
+                                            * (0.75D + 2.25D * (double) d.level / (double) d.getMaxLevel())
                                             * (0.9D + enchants.size() * 0.05D));
                             if (lpDiff + (double) lpRequired > (double) Integer.MAX_VALUE) {
                                 lpRequired = Integer.MAX_VALUE;

--- a/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
+++ b/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
@@ -158,7 +158,7 @@ public class RitualEffectEnchant extends RitualEffect {
                         if (player != null && !tooExpensive)
                             player.addChatComponentMessage(new ChatComponentText("Lp required: " + lpRequired));
                     }
-                    if (SoulNetworkHandler.getCurrentEssence(owner) >= lpRequired) {
+                    if (!tooExpensive && SoulNetworkHandler.getCurrentEssence(owner) >= lpRequired) {
                         SoulNetworkHandler.syphonFromNetwork(owner, lpRequired);
                         lpRequired = 0;
                         advanceStage();

--- a/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
+++ b/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
@@ -164,7 +164,12 @@ public class RitualEffectEnchant extends RitualEffect {
                     if (stageTicks >= 100) {
                         for (EnchantmentData d : enchants) {
                             if (EnchantmentHelper.getEnchantmentLevel(d.enchant, enchantItem) == 0) {
-                                enchantItem.addEnchantment(Enchantment.enchantmentsList[d.enchant], d.level);
+                                if (enchantItem.stackTagCompound == null) enchantItem.setTagCompound(new NBTTagCompound());
+                                if (!enchantItem.stackTagCompound.hasKey("ench", 9)) enchantmentItem.setTag("ench", new NBTTagList());
+                                NBTTagCompound ench = new NBTTagCompound();
+                                ench.setShort("id", (short)Enchantment.enchantmentsList[d.enchant].effectId);
+                                ench.setShort("lvl", (short)d.level);
+                                enchantItem.stackTagCompound.getTagList("ench", 10).appendTag(ench);
                             }
                         }
 

--- a/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
+++ b/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
@@ -35,7 +35,7 @@ public class RitualEffectEnchant extends RitualEffect {
     public int stage3EndTicks = 0;
 
     int lpRequired = -1;
-    boolean tooExpensive = false;
+    // boolean tooExpensive = false;
 
     public ItemStack enchantItem = null;
     public List<EnchantmentData> enchants = new ArrayList<>();
@@ -138,7 +138,6 @@ public class RitualEffectEnchant extends RitualEffect {
                 case 2: {
                     if (lpRequired == -1) {
                         lpRequired = 0;
-                        tooExpensive = false;
 
                         for (EnchantmentData d : enchants) {
                             Enchantment ench = Enchantment.enchantmentsList[d.enchant];
@@ -148,17 +147,16 @@ public class RitualEffectEnchant extends RitualEffect {
                                             * ((3D + d.level * d.level) * 0.25D)
                                             * (0.9D + enchants.size() * 0.05D));
                             if (lpDiff + (double) lpRequired > (double) Integer.MAX_VALUE) {
-                                tooExpensive = true;
                                 lpRequired = Integer.MAX_VALUE;
                                 break;
                             }
                             lpRequired += (int) lpDiff;
                             // lpRequired is an int so this can't sneak an overflow past prev check
                         }
-                        if (player != null && !tooExpensive)
+                        if (player != null)
                             player.addChatComponentMessage(new ChatComponentText("Lp required: " + lpRequired));
                     }
-                    if (!tooExpensive && SoulNetworkHandler.getCurrentEssence(owner) >= lpRequired) {
+                    if (SoulNetworkHandler.getCurrentEssence(owner) >= lpRequired) {
                         SoulNetworkHandler.syphonFromNetwork(owner, lpRequired);
                         lpRequired = 0;
                         advanceStage();

--- a/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
+++ b/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
@@ -140,10 +140,13 @@ public class RitualEffectEnchant extends RitualEffect {
 
                         for (EnchantmentData d : enchants) {
                             Enchantment ench = Enchantment.enchantmentsList[d.enchant];
-                            lpRequired += (int) (500F * ((15 - Math.min(15, ench.getWeight())) * 1.05F)
-                                    * ((3F + d.level * d.level) * 0.25F)
-                                    * (0.9F + enchants.size() * 0.05F));
+                            lpRequired += (int) Math.min(
+                                    1E8F,
+                                    500F * (Math.max(0, 15 - Math.min(15, ench.getWeight())) * 1.05F)
+                                            * ((3F + d.level * d.level) * 0.25F)
+                                            * (0.9F + enchants.size() * 0.05F));
                         }
+                        if (lpRequired < 0) lpRequired = Integer.MAX_VALUE;
                         if (player != null)
                             player.addChatComponentMessage(new ChatComponentText("Lp required: " + lpRequired));
                     }
@@ -164,11 +167,13 @@ public class RitualEffectEnchant extends RitualEffect {
                     if (stageTicks >= 100) {
                         for (EnchantmentData d : enchants) {
                             if (EnchantmentHelper.getEnchantmentLevel(d.enchant, enchantItem) == 0) {
-                                if (enchantItem.stackTagCompound == null) enchantItem.setTagCompound(new NBTTagCompound());
-                                if (!enchantItem.stackTagCompound.hasKey("ench", 9)) enchantmentItem.setTag("ench", new NBTTagList());
+                                if (enchantItem.stackTagCompound == null)
+                                    enchantItem.setTagCompound(new NBTTagCompound());
+                                if (!enchantItem.stackTagCompound.hasKey("ench", 9))
+                                    enchantItem.stackTagCompound.setTag("ench", new NBTTagList());
                                 NBTTagCompound ench = new NBTTagCompound();
-                                ench.setShort("id", (short)Enchantment.enchantmentsList[d.enchant].effectId);
-                                ench.setShort("lvl", (short)d.level);
+                                ench.setShort("id", (short) Enchantment.enchantmentsList[d.enchant].effectId);
+                                ench.setShort("lvl", (short) d.level);
                                 enchantItem.stackTagCompound.getTagList("ench", 10).appendTag(ench);
                             }
                         }

--- a/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
+++ b/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
@@ -143,7 +143,7 @@ public class RitualEffectEnchant extends RitualEffect {
                             Enchantment ench = Enchantment.enchantmentsList[d.enchant];
                             double lpDiff = Math.min(
                                     (double) Integer.MAX_VALUE,
-                                    500D * (Math.max(0, 15 - Math.min(15, ench.getWeight())) * 1.05D)
+                                    500D * (15D / (double) ench.getWeight() * 1.05D)
                                             * ((3D + d.level * d.level) * 0.25D)
                                             * (0.9D + enchants.size() * 0.05D));
                             if (lpDiff + (double) lpRequired > (double) Integer.MAX_VALUE) {

--- a/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
+++ b/src/main/java/com/arc/bloodarsenal/common/rituals/RitualEffectEnchant.java
@@ -144,7 +144,7 @@ public class RitualEffectEnchant extends RitualEffect {
                             double lpDiff = Math.min(
                                     (double) Integer.MAX_VALUE,
                                     500D * (15D / (double) ench.getWeight() * 1.05D)
-                                            * ((3D + d.level * d.level) * 0.25D)
+                                            * ((double) d.level * ((double) d.level * .01D + 5D) * 0.25D)
                                             * (0.9D + enchants.size() * 0.05D));
                             if (lpDiff + (double) lpRequired > (double) Integer.MAX_VALUE) {
                                 lpRequired = Integer.MAX_VALUE;


### PR DESCRIPTION
The ritual could give negative enchantment levels because of byte casting in the default MC enchant code (a mixin could fix it but this was easier).

There was also a risk of negative LP cost in the case of a high enchantment weight, combined with an overflow that can occur from n^2 scaling to the cost.

The mixin that fixes the ExU spike overchanter glitch should prevent any of these effects from occuring, but older worlds can still have overchanted books from this method.