### PR TITLE
Add glassProtectiveItems config

### DIFF
--- a/src/main/java/com/arc/bloodarsenal/common/BloodArsenal.java
+++ b/src/main/java/com/arc/bloodarsenal/common/BloodArsenal.java
@@ -188,5 +188,7 @@ public class BloodArsenal {
             logger.info("Loaded Forge Multipart integration");
             ModBlocks.registerMultiparts();
         }
+
+        BloodArsenalConfig.postInit();
     }
 }

--- a/src/main/java/com/arc/bloodarsenal/common/BloodArsenalConfig.java
+++ b/src/main/java/com/arc/bloodarsenal/common/BloodArsenalConfig.java
@@ -59,6 +59,7 @@ public class BloodArsenalConfig {
     public static boolean isRedGood;
     public static boolean cakeIsLie;
     public static boolean isGlassDangerous;
+    public static String[] glassProtectiveItems;
 
     public static void init(File file) {
         config = new Configuration(file);
@@ -151,6 +152,12 @@ public class BloodArsenalConfig {
         isGlassDangerous = config
                 .get(misc, "Is glass dangerous?", true, "Breaking glass is dangerous unless you're a wimp")
                 .getBoolean(isGlassDangerous);
+        glassProtectiveItems = config.get(
+                misc,
+                "Glass-protective Items",
+                new String[] { "matter-manipulator:itemMatterManipulator0", "matter-manipulator:itemMatterManipulator1",
+                        "matter-manipulator:itemMatterManipulator2", "matter-manipulator:itemMatterManipulator3" },
+                "Breaking glass with any of these items will not cause bleeding").getStringList();
 
         config.save();
     }

--- a/src/main/java/com/arc/bloodarsenal/common/BloodArsenalConfig.java
+++ b/src/main/java/com/arc/bloodarsenal/common/BloodArsenalConfig.java
@@ -1,6 +1,9 @@
 package com.arc.bloodarsenal.common;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import net.minecraftforge.common.config.Configuration;
 
@@ -59,7 +62,7 @@ public class BloodArsenalConfig {
     public static boolean isRedGood;
     public static boolean cakeIsLie;
     public static boolean isGlassDangerous;
-    public static String[] glassProtectiveItems;
+    public static Set<String> glassProtectiveItems;
 
     public static void init(File file) {
         config = new Configuration(file);
@@ -152,12 +155,17 @@ public class BloodArsenalConfig {
         isGlassDangerous = config
                 .get(misc, "Is glass dangerous?", true, "Breaking glass is dangerous unless you're a wimp")
                 .getBoolean(isGlassDangerous);
-        glassProtectiveItems = config.get(
-                misc,
-                "Glass-protective Items",
-                new String[] { "matter-manipulator:itemMatterManipulator0", "matter-manipulator:itemMatterManipulator1",
-                        "matter-manipulator:itemMatterManipulator2", "matter-manipulator:itemMatterManipulator3" },
-                "Breaking glass with any of these items will not cause bleeding").getStringList();
+        glassProtectiveItems = Arrays
+                .stream(
+                        config.get(
+                                misc,
+                                "Glass-protective Items",
+                                new String[] { "matter-manipulator:itemMatterManipulator0",
+                                        "matter-manipulator:itemMatterManipulator1",
+                                        "matter-manipulator:itemMatterManipulator2",
+                                        "matter-manipulator:itemMatterManipulator3" },
+                                "Breaking glass with any of these items will not cause bleeding").getStringList())
+                .collect(Collectors.toSet());
 
         config.save();
     }

--- a/src/main/java/com/arc/bloodarsenal/common/BloodArsenalConfig.java
+++ b/src/main/java/com/arc/bloodarsenal/common/BloodArsenalConfig.java
@@ -7,14 +7,13 @@ import java.util.Set;
 import net.minecraft.item.Item;
 import net.minecraftforge.common.config.Configuration;
 
-import com.gtnewhorizon.gtnhlib.util.data.Lazy;
-
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.common.registry.GameRegistry.UniqueIdentifier;
 
 public class BloodArsenalConfig {
 
     public static Configuration config;
+    private static boolean hasPostInit = false;
 
     // Config Categories
     public static String potionId = "Potion ID";
@@ -67,7 +66,8 @@ public class BloodArsenalConfig {
     public static boolean isRedGood;
     public static boolean cakeIsLie;
     public static boolean isGlassDangerous;
-    public static Lazy<Set<Item>> glassProtectiveItems;
+    public static Set<Item> glassProtectiveItems;
+    private static String[] glassProtectiveItemIds;
 
     public static void init(File file) {
         config = new Configuration(file);
@@ -161,25 +161,32 @@ public class BloodArsenalConfig {
                 .get(misc, "Is glass dangerous?", true, "Breaking glass is dangerous unless you're a wimp")
                 .getBoolean(isGlassDangerous);
 
-        String[] glassProtectiveItemIds = config.get(
+        glassProtectiveItemIds = config.get(
                 misc,
                 "Glass-protective Items",
                 new String[] { "matter-manipulator:itemMatterManipulator0", "matter-manipulator:itemMatterManipulator1",
                         "matter-manipulator:itemMatterManipulator2", "matter-manipulator:itemMatterManipulator3" },
                 "Breaking glass with any of these items will not cause bleeding").getStringList();
 
-        glassProtectiveItems = new Lazy<>(() -> {
-            HashSet<Item> set = new HashSet<>();
+        config.save();
+
+        // Run postInit() if the config was changed from in-game config menu
+        if (hasPostInit) {
+            postInit();
+        }
+    }
+
+    public static void postInit() {
+        hasPostInit = true;
+        glassProtectiveItems = new HashSet<>();
+        if (glassProtectiveItemIds != null) {
             for (String itemId : glassProtectiveItemIds) {
                 UniqueIdentifier id = new UniqueIdentifier(itemId);
                 Item item = GameRegistry.findItem(id.modId, id.name);
                 if (item != null) {
-                    set.add(item);
+                    glassProtectiveItems.add(item);
                 }
             }
-            return set;
-        });
-
-        config.save();
+        }
     }
 }

--- a/src/main/java/com/arc/bloodarsenal/common/BloodArsenalConfig.java
+++ b/src/main/java/com/arc/bloodarsenal/common/BloodArsenalConfig.java
@@ -1,11 +1,16 @@
 package com.arc.bloodarsenal.common;
 
 import java.io.File;
-import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 
+import net.minecraft.item.Item;
 import net.minecraftforge.common.config.Configuration;
+
+import com.gtnewhorizon.gtnhlib.util.data.Lazy;
+
+import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.common.registry.GameRegistry.UniqueIdentifier;
 
 public class BloodArsenalConfig {
 
@@ -62,7 +67,7 @@ public class BloodArsenalConfig {
     public static boolean isRedGood;
     public static boolean cakeIsLie;
     public static boolean isGlassDangerous;
-    public static Set<String> glassProtectiveItems;
+    public static Lazy<Set<Item>> glassProtectiveItems;
 
     public static void init(File file) {
         config = new Configuration(file);
@@ -155,17 +160,25 @@ public class BloodArsenalConfig {
         isGlassDangerous = config
                 .get(misc, "Is glass dangerous?", true, "Breaking glass is dangerous unless you're a wimp")
                 .getBoolean(isGlassDangerous);
-        glassProtectiveItems = Arrays
-                .stream(
-                        config.get(
-                                misc,
-                                "Glass-protective Items",
-                                new String[] { "matter-manipulator:itemMatterManipulator0",
-                                        "matter-manipulator:itemMatterManipulator1",
-                                        "matter-manipulator:itemMatterManipulator2",
-                                        "matter-manipulator:itemMatterManipulator3" },
-                                "Breaking glass with any of these items will not cause bleeding").getStringList())
-                .collect(Collectors.toSet());
+
+        String[] glassProtectiveItemIds = config.get(
+                misc,
+                "Glass-protective Items",
+                new String[] { "matter-manipulator:itemMatterManipulator0", "matter-manipulator:itemMatterManipulator1",
+                        "matter-manipulator:itemMatterManipulator2", "matter-manipulator:itemMatterManipulator3" },
+                "Breaking glass with any of these items will not cause bleeding").getStringList();
+
+        glassProtectiveItems = new Lazy<>(() -> {
+            HashSet<Item> set = new HashSet<>();
+            for (String itemId : glassProtectiveItemIds) {
+                UniqueIdentifier id = new UniqueIdentifier(itemId);
+                Item item = GameRegistry.findItem(id.modId, id.name);
+                if (item != null) {
+                    set.add(item);
+                }
+            }
+            return set;
+        });
 
         config.save();
     }

--- a/src/main/java/com/arc/bloodarsenal/common/BloodArsenalEventHooks.java
+++ b/src/main/java/com/arc/bloodarsenal/common/BloodArsenalEventHooks.java
@@ -1,5 +1,6 @@
 package com.arc.bloodarsenal.common;
 
+import java.util.Arrays;
 import java.util.Random;
 
 import net.minecraft.block.Block;
@@ -10,6 +11,7 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Items;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
@@ -26,6 +28,7 @@ import WayofTime.alchemicalWizardry.api.soulNetwork.SoulNetworkHandler;
 import cpw.mods.fml.client.event.ConfigChangedEvent;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.common.registry.GameRegistry.UniqueIdentifier;
 
 public class BloodArsenalEventHooks {
 
@@ -169,8 +172,9 @@ public class BloodArsenalEventHooks {
             if (player != null && player instanceof EntityPlayerMP && !(player instanceof FakePlayer)) {
                 if (!event.world.isRemote && !event.isSilkTouching) {
                     if (block != null && block instanceof BlockGlass) {
-                        if (player.getCurrentEquippedItem() != null
-                                && player.getCurrentEquippedItem().getItem() == Items.flint) {
+                        ItemStack equippedItemStack = player.getCurrentEquippedItem();
+                        Item equippedItem = equippedItemStack != null ? equippedItemStack.getItem() : null;
+                        if (equippedItem == Items.flint) {
                             event.drops.add(new ItemStack(ModItems.glass_shard));
                             if (random.nextInt() + 5 < 8) {
                                 event.drops.add(new ItemStack(ModItems.glass_shard));
@@ -183,8 +187,13 @@ public class BloodArsenalEventHooks {
                             }
                         } else {
                             if (BloodArsenalConfig.isGlassDangerous && random.nextInt(3) == 2) {
-                                player.addPotionEffect(
-                                        new PotionEffect(BloodArsenal.bleeding.id, 8 * 20, random.nextInt(3)));
+                                UniqueIdentifier equippedItemId = GameRegistry.findUniqueIdentifierFor(equippedItem);
+                                String equippedItemIdStr = equippedItemId == null ? null : equippedItemId.toString();
+                                if (equippedItemIdStr != null && Arrays.stream(BloodArsenalConfig.glassProtectiveItems)
+                                        .noneMatch(s -> s.equals(equippedItemIdStr))) {
+                                    player.addPotionEffect(
+                                            new PotionEffect(BloodArsenal.bleeding.id, 8 * 20, random.nextInt(3)));
+                                }
                             }
                         }
                     }

--- a/src/main/java/com/arc/bloodarsenal/common/BloodArsenalEventHooks.java
+++ b/src/main/java/com/arc/bloodarsenal/common/BloodArsenalEventHooks.java
@@ -185,7 +185,7 @@ public class BloodArsenalEventHooks {
                             }
                         } else {
                             if (BloodArsenalConfig.isGlassDangerous && random.nextInt(3) == 2) {
-                                if (!BloodArsenalConfig.glassProtectiveItems.get().contains(equippedItem)) {
+                                if (!BloodArsenalConfig.glassProtectiveItems.contains(equippedItem)) {
                                     player.addPotionEffect(
                                             new PotionEffect(BloodArsenal.bleeding.id, 8 * 20, random.nextInt(3)));
                                 }

--- a/src/main/java/com/arc/bloodarsenal/common/BloodArsenalEventHooks.java
+++ b/src/main/java/com/arc/bloodarsenal/common/BloodArsenalEventHooks.java
@@ -27,7 +27,6 @@ import WayofTime.alchemicalWizardry.api.soulNetwork.SoulNetworkHandler;
 import cpw.mods.fml.client.event.ConfigChangedEvent;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.registry.GameRegistry;
-import cpw.mods.fml.common.registry.GameRegistry.UniqueIdentifier;
 
 public class BloodArsenalEventHooks {
 
@@ -186,9 +185,7 @@ public class BloodArsenalEventHooks {
                             }
                         } else {
                             if (BloodArsenalConfig.isGlassDangerous && random.nextInt(3) == 2) {
-                                UniqueIdentifier equippedItemId = GameRegistry.findUniqueIdentifierFor(equippedItem);
-                                String equippedItemIdStr = equippedItemId == null ? null : equippedItemId.toString();
-                                if (!BloodArsenalConfig.glassProtectiveItems.contains(equippedItemIdStr)) {
+                                if (!BloodArsenalConfig.glassProtectiveItems.get().contains(equippedItem)) {
                                     player.addPotionEffect(
                                             new PotionEffect(BloodArsenal.bleeding.id, 8 * 20, random.nextInt(3)));
                                 }

--- a/src/main/java/com/arc/bloodarsenal/common/BloodArsenalEventHooks.java
+++ b/src/main/java/com/arc/bloodarsenal/common/BloodArsenalEventHooks.java
@@ -1,6 +1,5 @@
 package com.arc.bloodarsenal.common;
 
-import java.util.Arrays;
 import java.util.Random;
 
 import net.minecraft.block.Block;
@@ -189,8 +188,7 @@ public class BloodArsenalEventHooks {
                             if (BloodArsenalConfig.isGlassDangerous && random.nextInt(3) == 2) {
                                 UniqueIdentifier equippedItemId = GameRegistry.findUniqueIdentifierFor(equippedItem);
                                 String equippedItemIdStr = equippedItemId == null ? null : equippedItemId.toString();
-                                if (equippedItemIdStr != null && Arrays.stream(BloodArsenalConfig.glassProtectiveItems)
-                                        .noneMatch(s -> s.equals(equippedItemIdStr))) {
+                                if (!BloodArsenalConfig.glassProtectiveItems.contains(equippedItemIdStr)) {
                                     player.addPotionEffect(
                                             new PotionEffect(BloodArsenal.bleeding.id, 8 * 20, random.nextInt(3)));
                                 }


### PR DESCRIPTION
This PR adds a new config value for a list of items that allow the player to break glass blocks without the risk of bleeding. The main purpose of this is to allow the player to use the matter manipulator to remove glass freely.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23674